### PR TITLE
Separate migration tests and unit tests

### DIFF
--- a/src/main/groovy/org/bonitasoft/migration/plugin/dist/MigrationDistribution.groovy
+++ b/src/main/groovy/org/bonitasoft/migration/plugin/dist/MigrationDistribution.groovy
@@ -18,6 +18,7 @@ import org.bonitasoft.migration.plugin.MigrationConstants
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.testing.Test
 
 /**
  *
@@ -138,9 +139,17 @@ class MigrationDistribution implements Plugin<Project> {
         testProject.tasks.setupSourceEngine {
             doFirst setSystemPropertiesForEngine
         }
-        testProject.tasks.test {
+
+        testProject.task(TASK_TEST_MIGRATION, type: Test) {
+            description = "Launch tests after the migration. Optional -D parameters: target.version"
+            testClassesDir = testProject.sourceSets.test.output.classesDir
+            classpath = testProject.sourceSets.test.runtimeClasspath
+        }
+
+        testProject.tasks.testMigration {
             doFirst setSystemPropertiesForEngine
         }
+
         //Define task flow
         project.tasks.migrate.dependsOn project.tasks.unpackBonitaHomeSource
         project.tasks.migrate.dependsOn {
@@ -159,7 +168,7 @@ class MigrationDistribution implements Plugin<Project> {
 
         project.tasks.migrate.dependsOn testProject.tasks.setupSourceEngine
 
-        project.tasks.testMigration.dependsOn testProject.tasks.test
+        project.tasks.testMigration.dependsOn testProject.tasks.testMigration
         project.tasks.testMigration.dependsOn project.tasks.migrate
         project.tasks.testMigration.dependsOn project.tasks.distZip
     }

--- a/src/main/groovy/org/bonitasoft/migration/plugin/project/MigrationProject.groovy
+++ b/src/main/groovy/org/bonitasoft/migration/plugin/project/MigrationProject.groovy
@@ -74,6 +74,11 @@ class MigrationProject implements Plugin<Project> {
                 group = MIGRATION_PROJECT_GROUP
             }
             tasks.setupSourceEngine.dependsOn tasks.jar
+
+            // tests related to migration tests should be executed only using testMigration task
+            tasks.test {
+                exclude '**'
+            }
         }
     }
 


### PR DESCRIPTION
 Running 'gradle test' will launch unit tests from 'migration-distrib', but do not launch tests from 'migrateTo...' modules
 Running 'gradle testMigration' will run only test from  'migrateTo...' modules
