### PR TITLE
Standardize names of system properties

### DIFF
--- a/src/main/groovy/org/bonitasoft/migration/plugin/dist/MigrationDistribution.groovy
+++ b/src/main/groovy/org/bonitasoft/migration/plugin/dist/MigrationDistribution.groovy
@@ -136,11 +136,11 @@ class MigrationDistribution implements Plugin<Project> {
         Project testProject = getTestProject(project, project.target)
         def setSystemPropertiesForEngine = {
             systemProperties = [
-                    "dbvendor"     : String.valueOf(project.database.properties.dbvendor),
-                    "dburl"        : String.valueOf(project.database.properties.dburl),
-                    "dbuser"       : String.valueOf(project.database.properties.dbuser),
-                    "dbpassword"   : String.valueOf(project.database.properties.dbpassword),
-                    "dbdriverClass": String.valueOf(project.database.properties.dbdriverClass),
+                    "db.vendor"     : String.valueOf(project.database.properties.dbvendor),
+                    "db.url"        : String.valueOf(project.database.properties.dburl),
+                    "db.user"       : String.valueOf(project.database.properties.dbuser),
+                    "db.password"   : String.valueOf(project.database.properties.dbpassword),
+                    "db.driverClass": String.valueOf(project.database.properties.dbdriverClass),
                     "bonita.home"  : String.valueOf(project.rootProject.buildDir.absolutePath + File.separator + "bonita-home"),
             ]
         }


### PR DESCRIPTION
The same system properties was referenced with a dot and without a dot (dbuser and db.user): always use pattern  with a dot
